### PR TITLE
Remove "Legal name" from non-inclusive list

### DIFF
--- a/inclusive-communication.md
+++ b/inclusive-communication.md
@@ -33,7 +33,6 @@ Please do submit any edits you feel necessary, and these will be reviewed and me
 | -------------------- | ---------------- |
 | Blackbox             | Closed / Opaque box |
 | Whitebox             | Open / Clear box |
-| Legal name           | Preferred name and pronouns (put yours on your email signature) |
 | God mode             | Staff mode / CSR mode / Admin mode |
 | Back of a fag packet | Back of an envelope/napkin |
 | Straw man            | Straw person/head |


### PR DESCRIPTION
There is some confusion about what context "legal name" would ever be used at the Guardian, and if preferred name would be an acceptable alternative.  So it seems more helpful to remove this entry.

Also, I wasn't clear when reading this entry whether it was suggesting "Preferred name" and "Preferred pronouns" or "Preferred name" and "pronouns".  But the phrase "preferred pronouns" is no longer used. Terms like this make it sound like someone’s gender is up for debate. We can just use the word "pronouns".