### PR TITLE
add link to DialPad document which has more examples

### DIFF
--- a/inclusive-communication.md
+++ b/inclusive-communication.md
@@ -37,6 +37,9 @@ Please do submit any edits you feel necessary, and these will be reviewed and me
 | Back of a fag packet | Back of an envelope/napkin |
 | Straw man            | Straw person/head |
 | mental               | unbelievable/horrible |
+
+#### comprehensive DialPad list
+https://github.com/dialpad/inclusive-language
   
 
 ## Accountability

--- a/inclusive-communication.md
+++ b/inclusive-communication.md
@@ -38,7 +38,7 @@ Please do submit any edits you feel necessary, and these will be reviewed and me
 | Straw man            | Straw person/head |
 | mental               | unbelievable/horrible |
 
-#### comprehensive DialPad list
+#### Longer list from DialPad
 https://github.com/dialpad/inclusive-language
   
 


### PR DESCRIPTION
This PR adds a link on the inclusive language doc to these examples and recommendations
https://github.com/dialpad/inclusive-language

Thre could probably be a more comprehensive update of our doc to work better with this other doc, but for now at least a link is useful.